### PR TITLE
Added regular expression assertions

### DIFF
--- a/executors/tavern/README.md
+++ b/executors/tavern/README.md
@@ -194,6 +194,6 @@ testcases:
         FirstName: "Adeline"
         LastName:  "Durand"
       jsonExcludes: *excludes
-...
+```
 
 *Enjoy!*

--- a/executors/tavern/README.md
+++ b/executors/tavern/README.md
@@ -125,6 +125,8 @@ To perform regexp assertions on headers, you must declare headers to assert in `
 ```yaml
 headers:
     Set-Cookie: "foo=bar; Path=/; Expires=.*?; HttpOnly; SameSite=None"
+headersRegexps:
+- "Set-Cookie"
 ```
 
 To perform regexp assertions on JSON structure, you must declare fields to assert in `json` clause, then list regexp fields in `jsonRegexps`, as follows:
@@ -134,7 +136,7 @@ json:
     foo: "bar"
     spam: "e.*s"
 jsonRegexps:
-- spam
+- "spam"
 ```
 
 This will assert that *spam* JSON field matches `e.*s` regexp. Assertion on *foo* fields will be performed with equality as usual.

--- a/executors/tavern/README.md
+++ b/executors/tavern/README.md
@@ -63,13 +63,18 @@ For *multipartform*, *basicauth*, *ignoreverifyssl*, *proxy*, *resolve*, *nofoll
 
 Possible fields are:
 
-- **StatusCode**: expected status code
-- **Headers**: expected headers as a map (only defined headers are tested)
-- **Body**: expected text body
-- **Json**: expected JSON body as a structure
-- **JsonExcludes**: a list of paths to excludes from test in JSON response
+- **statusCode**: expected status code
+- **headers**: expected headers as a map (only defined headers are tested)
+- **headersRegexps**: list of headers assertions that are regexps
+- **body**: expected text body
+- **bodyRegexp**: regexp for expected body
+- **json**: expected JSON body as a structure
+- **jsonExcludes**: a list of paths to excludes from test in JSON response
+- **jsonRegexps**: list of json fields assertions that are regexps
 
 Fields that are not set are not checked. Only defined headers are checked, thus Tavern executor won't complain about an additional header.
+
+## Json Excludes
 
 You can exclude paths from JSON during test. For instance, to exclude field `CreationDate` during response comparison, you might add in `response` field:
 
@@ -104,6 +109,35 @@ Thus:
 - **text** matches given entry
 - **\*** matches any entry
 - **\*\*** matches any entries in successive levels
+
+## Regular Expressions
+
+You can perform assertions with regular expressions.
+
+To perform a body assertion with regular expression, you can use `bodyRegexp`. Thus you might write:
+
+```yaml
+bodyRegexp: "Foo.*Bar"
+```
+
+To perform regexp assertions on headers, you must declare headers to assert in `headers` clause, then list regexp fields in `headersRegexps`, as follows:
+
+```yaml
+headers:
+    Set-Cookie: "foo=bar; Path=/; Expires=.*?; HttpOnly; SameSite=None"
+```
+
+To perform regexp assertions on JSON structure, you must declare fields to assert in `json` clause, then list regexp fields in `jsonRegexps`, as follows:
+
+```yaml
+json:
+    foo: "bar"
+    spam: "e.*s"
+jsonRegexps:
+- spam
+```
+
+This will assert that *spam* JSON field matches `e.*s` regexp. Assertion on *foo* fields will be performed with equality as usual.
 
 ## Default Assertions
 

--- a/executors/tavern/assert.go
+++ b/executors/tavern/assert.go
@@ -149,7 +149,7 @@ func FilterChangelogRegexps(changelog []diff.Change, filters []string) ([]diff.C
 					if !ok {
 						return nil, fmt.Errorf("regexp filter %s is not a string", path)
 					}
-					m, e := regexp.MatchString(to, from)
+					m, e := regexp.MatchString(from, to)
 					if e != nil {
 						return nil, fmt.Errorf("invalid field regexp: %v", err)
 					}

--- a/executors/tavern/assert.go
+++ b/executors/tavern/assert.go
@@ -22,6 +22,9 @@ func AssertResponse(actual interface{}, expected ...interface{}) error {
 	if !ok {
 		return fmt.Errorf("bad actual type: expected: Result, actual: %T", actual)
 	}
+	if err := CheckAssertions(result.Expected); err != nil {
+		return err
+	}
 	// check status code
 	if result.Expected.StatusCode != 0 {
 		if result.Expected.StatusCode != result.Actual.StatusCode {
@@ -30,14 +33,25 @@ func AssertResponse(actual interface{}, expected ...interface{}) error {
 		}
 	}
 	// check expected headers
-	for k, v := range result.Expected.Headers {
-		value, ok := result.Actual.Headers[k]
+	for key, expected := range result.Expected.Headers {
+		actual, ok := result.Actual.Headers[key]
 		if !ok {
-			return fmt.Errorf("header '%s' not found in response", k)
+			return fmt.Errorf("header '%s' not found in response", key)
 		}
-		if value != v {
-			return fmt.Errorf("bad header '%s' value: expected: '%s', actual: '%s'",
-				k, v, value)
+		if ElementInList(key, result.Expected.HeadersRegexps) {
+			match, err := regexp.MatchString(expected, actual)
+			if err != nil {
+				return fmt.Errorf("bad headers regexp: %v", err)
+			}
+			if !match {
+				return fmt.Errorf("bad header '%s' value: regexp: '%s', doesn't match: '%s'",
+					key, expected, actual)
+			}
+		} else {
+			if actual != expected {
+				return fmt.Errorf("bad header '%s' value: expected: '%s', actual: '%s'",
+					key, expected, actual)
+			}
 		}
 	}
 	// check expected body
@@ -45,6 +59,16 @@ func AssertResponse(actual interface{}, expected ...interface{}) error {
 		if result.Expected.Body != result.Actual.Body {
 			return fmt.Errorf("bad body: expected: '%s', actual: '%s'",
 				result.Expected.Body, result.Actual.Body)
+		}
+	}
+	// check expected body
+	if result.Expected.BodyRegexp != "" {
+		match, err := regexp.MatchString(result.Expected.BodyRegexp, result.Actual.Body)
+		if err != nil {
+			return fmt.Errorf("bad body regexp: %v", err)
+		}
+		if !match {
+			return fmt.Errorf("body doesn't match regexp '%s'", result.Expected.BodyRegexp)
 		}
 	}
 	// check expected JSON body
@@ -56,7 +80,14 @@ func AssertResponse(actual interface{}, expected ...interface{}) error {
 			}
 			if len(result.Expected.JSONExcludes) != 0 {
 				var err error
-				changelog, err = FilterChangelog(changelog, result.Expected.JSONExcludes)
+				changelog, err = FilterChangelogExcludes(changelog, result.Expected.JSONExcludes)
+				if err != nil {
+					return err
+				}
+			}
+			if len(result.Expected.JSONRegexps) != 0 {
+				var err error
+				changelog, err = FilterChangelogRegexps(changelog, result.Expected.JSONRegexps)
 				if err != nil {
 					return err
 				}
@@ -64,7 +95,7 @@ func AssertResponse(actual interface{}, expected ...interface{}) error {
 			if len(changelog) != 0 {
 				var diffs []string
 				for _, change := range changelog {
-					diffs = append(diffs, ChangeMessage(change))
+					diffs = append(diffs, ChangeMessage(change, result.Expected.JSONRegexps))
 				}
 				changes := strings.Join(diffs, "; ")
 				return fmt.Errorf("diffs in json: %s", changes)
@@ -74,8 +105,8 @@ func AssertResponse(actual interface{}, expected ...interface{}) error {
 	return nil
 }
 
-// FilterChangelog filters changelog with JSON excluded fields
-func FilterChangelog(changelog []diff.Change, filters []string) ([]diff.Change, error) {
+// FilterChangelogExcludes filters changelog with JSON excluded fields
+func FilterChangelogExcludes(changelog []diff.Change, filters []string) ([]diff.Change, error) {
 	var filteredChangelog []diff.Change
 	for _, change := range changelog {
 		filtered := false
@@ -97,10 +128,52 @@ func FilterChangelog(changelog []diff.Change, filters []string) ([]diff.Change, 
 	return filteredChangelog, nil
 }
 
+// FilterChangelogRegexps filters changelog with Regexp fields
+func FilterChangelogRegexps(changelog []diff.Change, filters []string) ([]diff.Change, error) {
+	var filteredChangelog []diff.Change
+	for _, change := range changelog {
+		filtered := false
+		path := FormatPath(change.Path)
+		for _, filter := range filters {
+			match, err := regexp.MatchString(PathToRegexp(filter), path)
+			if err != nil {
+				return nil, fmt.Errorf("invalid filter regexp: %v", err)
+			}
+			if match {
+				if change.Type == diff.UPDATE {
+					from, ok := change.From.(string)
+					if !ok {
+						return nil, fmt.Errorf("regexp field %s is not a string", path)
+					}
+					to, ok := change.To.(string)
+					if !ok {
+						return nil, fmt.Errorf("regexp filter %s is not a string", path)
+					}
+					m, e := regexp.MatchString(to, from)
+					if e != nil {
+						return nil, fmt.Errorf("invalid field regexp: %v", err)
+					}
+					if m {
+						filtered = true
+					}
+				}
+				continue
+			}
+		}
+		if !filtered {
+			filteredChangelog = append(filteredChangelog, change)
+		}
+	}
+	return filteredChangelog, nil
+}
+
 // ChangeMessage generates human readable change message
-func ChangeMessage(change diff.Change) string {
+func ChangeMessage(change diff.Change, jsonRegexps []string) string {
 	if change.Type == diff.UPDATE {
 		path := FormatPath(change.Path)
+		if ElementInList(path, jsonRegexps) {
+			return fmt.Sprintf(`expected:%s = "%v" !~ actual:%s = "%v"`, path, change.From, path, change.To)
+		}
 		return fmt.Sprintf(`expected:%s = "%v" != actual:%s = "%v"`, path, change.From, path, change.To)
 	}
 	if change.Type == diff.CREATE {
@@ -127,10 +200,38 @@ func PathToRegexp(path string) string {
 		if element == "*" {
 			parts = append(parts, "[^/]+/")
 		} else if element == "**" {
-			parts = append(parts, "(.*?/)?")
+			parts = append(parts, ".*/?")
 		} else {
 			parts = append(parts, element+"/")
 		}
 	}
 	return "^" + strings.TrimSuffix(strings.Join(parts, ""), "/") + "$"
+}
+
+// ElementInList tells if given path is in filters list
+func ElementInList(path string, filters[]string) bool {
+	for _, filter := range filters {
+		if filter == path {
+			return true
+		}
+	}
+	return false
+}
+
+// CheckAssertions check incompatibles assertions
+func CheckAssertions(expected Response) error {
+	if expected.Body != "" && expected.BodyRegexp != "" {
+		return fmt.Errorf("you can set both body and bodyRegexps assertions")
+	}
+	for _, regexp := range expected.HeadersRegexps {
+		if _, ok := expected.Headers[regexp]; !ok {
+			return fmt.Errorf("field %s declared as regexp but not found in headers list", regexp)
+		}
+	}
+	for _, regexp := range expected.JSONRegexps {
+		if ElementInList(regexp, expected.JSONExcludes) {
+			return fmt.Errorf("JSON field '%s' can't be excluded and declared as regexp", regexp)
+		}
+	}
+	return nil
 }

--- a/executors/tavern/assert_test.go
+++ b/executors/tavern/assert_test.go
@@ -91,6 +91,40 @@ func TestAssertResponseHeaders(t *testing.T) {
 	if err.Error() != "bad header 'Foo' value: expected: 'Bar', actual: 'Baz'" {
 		t.Fatalf("bad error message: %s", err.Error())
 	}
+	// nominal case with regexp
+	result = Result{
+		Expected: Response{
+			Headers: Headers{"Foo": "B.r"},
+			HeadersRegexps: []string{"Foo"},
+		},
+		Actual: Response{
+			Headers: Headers{
+				"Foo":  "Bar",
+				"Spam": "Eggs",
+			},
+		},
+	}
+	err = AssertResponse(result)
+	if err != nil {
+		t.Fatalf("should have succeeded: %v", err)
+	}
+	// no match with regexp
+	result = Result{
+		Expected: Response{
+			Headers: Headers{"Foo": "x.*"},
+			HeadersRegexps: []string{"Foo"},
+		},
+		Actual: Response{
+			Headers: Headers{
+				"Foo":  "Bar",
+				"Spam": "Eggs",
+			},
+		},
+	}
+	err = AssertResponse(result)
+	if err == nil {
+		t.Fatalf("should not have succeeded: %v", err)
+	}
 }
 
 func TestAssertResponseBody(t *testing.T) {
@@ -111,6 +145,28 @@ func TestAssertResponseBody(t *testing.T) {
 		t.Fatalf("should have failed")
 	}
 	if err.Error() != "bad body: expected: 'Foo', actual: 'Bar'" {
+		t.Fatalf("bad error message: %s", err.Error())
+	}
+}
+
+func TestAssertResponseBodyRegexp(t *testing.T) {
+	result := Result{
+		Expected: Response{BodyRegexp: "F.o"},
+		Actual:   Response{Body: "Foo"},
+	}
+	err := AssertResponse(result)
+	if err != nil {
+		t.Fatalf("should have succeeded")
+	}
+	result = Result{
+		Expected: Response{BodyRegexp: "x.*"},
+		Actual:   Response{Body: "Foo"},
+	}
+	err = AssertResponse(result)
+	if err == nil {
+		t.Fatalf("should have failed")
+	}
+	if err.Error() != "body doesn't match regexp 'x.*'" {
 		t.Fatalf("bad error message: %s", err.Error())
 	}
 }
@@ -254,6 +310,50 @@ func TestAssertResponseJsonExcludes(t *testing.T) {
 	}
 }
 
+func TestAssertResponseJsonRegexps(t *testing.T) {
+	// nominal case
+	var expected interface{}
+	err := json.Unmarshal([]byte(`{"foo": "bar"}`), &expected)
+	if err != nil {
+		t.Fatalf("unmarshaling JSON: %v", err)
+	}
+	var actual interface{}
+	err = json.Unmarshal([]byte(`{"foo": "b.r"}`), &actual)
+	if err != nil {
+		t.Fatalf("unmarshaling JSON: %v", err)
+	}
+	result := Result{
+		Expected: Response{
+			JSON:        expected,
+			JSONRegexps: []string{"foo"},
+		},
+		Actual: Response{JSON: actual},
+	}
+	err = AssertResponse(result)
+	if err != nil {
+		t.Fatalf("should have succeeded: %v", err)
+	}
+	// no match
+	err = json.Unmarshal([]byte(`{"foo": "x.*"}`), &actual)
+	if err != nil {
+		t.Fatalf("unmarshaling JSON: %v", err)
+	}
+	result = Result{
+		Expected: Response{
+			JSON:        expected,
+			JSONRegexps: []string{"foo"},
+		},
+		Actual: Response{JSON: actual},
+	}
+	err = AssertResponse(result)
+	if err == nil {
+		t.Fatalf("should have failed: %v", err)
+	}
+	if err.Error() != `diffs in json: expected:foo = "bar" !~ actual:foo = "x.*"` {
+		t.Fatalf("bad diff message: %v", err)
+	}
+}
+
 func TestFilterChangelog(t *testing.T) {
 	changelog := []diff.Change{
 		{
@@ -265,7 +365,7 @@ func TestFilterChangelog(t *testing.T) {
 	}
 	// simple two levels path
 	filters := []string{"foo/bar"}
-	filtered, err := FilterChangelog(changelog, filters)
+	filtered, err := FilterChangelogExcludes(changelog, filters)
 	if err != nil {
 		t.Fatalf("error filtering changelog: %v", err)
 	}
@@ -274,7 +374,7 @@ func TestFilterChangelog(t *testing.T) {
 	}
 	// path with star in first position
 	filters = []string{"*/bar"}
-	filtered, err = FilterChangelog(changelog, filters)
+	filtered, err = FilterChangelogExcludes(changelog, filters)
 	if err != nil {
 		t.Fatalf("error filtering changelog: %v", err)
 	}
@@ -283,7 +383,7 @@ func TestFilterChangelog(t *testing.T) {
 	}
 	// path with star in second position
 	filters = []string{"foo/*"}
-	filtered, err = FilterChangelog(changelog, filters)
+	filtered, err = FilterChangelogExcludes(changelog, filters)
 	if err != nil {
 		t.Fatalf("error filtering changelog: %v", err)
 	}
@@ -292,7 +392,7 @@ func TestFilterChangelog(t *testing.T) {
 	}
 	// path with two stars
 	filters = []string{"*/*"}
-	filtered, err = FilterChangelog(changelog, filters)
+	filtered, err = FilterChangelogExcludes(changelog, filters)
 	if err != nil {
 		t.Fatalf("error filtering changelog: %v", err)
 	}
@@ -301,7 +401,7 @@ func TestFilterChangelog(t *testing.T) {
 	}
 	// path with a double star
 	filters = []string{"**"}
-	filtered, err = FilterChangelog(changelog, filters)
+	filtered, err = FilterChangelogExcludes(changelog, filters)
 	if err != nil {
 		t.Fatalf("error filtering changelog: %v", err)
 	}
@@ -310,7 +410,7 @@ func TestFilterChangelog(t *testing.T) {
 	}
 	// path with a double star and path
 	filters = []string{"**/bar"}
-	filtered, err = FilterChangelog(changelog, filters)
+	filtered, err = FilterChangelogExcludes(changelog, filters)
 	if err != nil {
 		t.Fatalf("error filtering changelog: %v", err)
 	}
@@ -319,7 +419,7 @@ func TestFilterChangelog(t *testing.T) {
 	}
 	// path with path and a double star
 	filters = []string{"foo/**"}
-	filtered, err = FilterChangelog(changelog, filters)
+	filtered, err = FilterChangelogExcludes(changelog, filters)
 	if err != nil {
 		t.Fatalf("error filtering changelog: %v", err)
 	}
@@ -328,7 +428,7 @@ func TestFilterChangelog(t *testing.T) {
 	}
 	// no filter
 	filters = []string{"spam/eggs"}
-	filtered, err = FilterChangelog(changelog, filters)
+	filtered, err = FilterChangelogExcludes(changelog, filters)
 	if err != nil {
 		t.Fatalf("error filtering changelog: %v", err)
 	}
@@ -345,25 +445,30 @@ func TestChangeMessage(t *testing.T) {
 		Path: []string{"foo", "bar"},
 	}
 	// update
-	message := ChangeMessage(change)
+	message := ChangeMessage(change, nil)
 	if message != `expected:foo/bar = "spam" != actual:foo/bar = "eggs"` {
+		t.Fatalf("bad change message: %v", message)
+	}
+	// update with regexp
+	message = ChangeMessage(change, []string{"foo/bar"})
+	if message != `expected:foo/bar = "spam" !~ actual:foo/bar = "eggs"` {
 		t.Fatalf("bad change message: %v", message)
 	}
 	// create
 	change.Type = diff.CREATE
-	message = ChangeMessage(change)
+	message = ChangeMessage(change, nil)
 	if message != `actual:foo/bar = "eggs" not in expected` {
 		t.Fatalf("bad change message: %v", message)
 	}
 	// delete
 	change.Type = diff.DELETE
-	message = ChangeMessage(change)
+	message = ChangeMessage(change, nil)
 	if message != `expected:foo/bar = "spam" not in actual` {
 		t.Fatalf("bad change message: %v", message)
 	}
 	// unknown
 	change.Type = "unknown"
-	message = ChangeMessage(change)
+	message = ChangeMessage(change, nil)
 	if message != `UNKNOWN TYPE unknown` {
 		t.Fatalf("bad change message: %v", message)
 	}
@@ -394,12 +499,15 @@ func TestPathToRegexp(t *testing.T) {
 	}
 	path = "foo/**"
 	regex = PathToRegexp(path)
-	if regex != "^foo/(.*?/)?$" {
+	if regex != "^foo/.*/?$" {
 		t.Fatalf("bad path regexp: %s", regex)
 	}
 	path = "**/bar"
 	regex = PathToRegexp(path)
-	if regex != "^(.*?/)?bar$" {
+	if regex != "^.*/?bar$" {
 		t.Fatalf("bad path regexp: %s", regex)
 	}
+}
+
+func TextCheckAssertions(t *testing.T) {
 }

--- a/executors/tavern/tavern.go
+++ b/executors/tavern/tavern.go
@@ -70,11 +70,14 @@ type Request struct {
 
 // Response describes expected response from server
 type Response struct {
-	StatusCode   int         `json:"statusCode,omitempty" yaml:"statusCode,omitempty"`
-	Headers      Headers     `json:"headers,omitempty" yaml:"headers,omitempty"`
-	Body         string      `json:"body,omitempty" yaml:"body,omitempty"`
-	JSON         interface{} `json:"json,omitempty" yaml:"json,omitempty"`
-	JSONExcludes []string    `json:"json_excludes,omitempty" yaml:"json_excludes,omitempty"`
+	StatusCode     int         `json:"statusCode,omitempty" yaml:"statusCode,omitempty"`
+	Headers        Headers     `json:"headers,omitempty" yaml:"headers,omitempty"`
+	HeadersRegexps []string    `json:"headers_regexps,omitempty" yaml:"headers_regexps,omitempty"`
+	Body           string      `json:"body,omitempty" yaml:"body,omitempty"`
+	BodyRegexp     string      `json:"body_regexp,omitempty" yaml:"body_regexp,omitempty"`
+	JSON           interface{} `json:"json,omitempty" yaml:"json,omitempty"`
+	JSONExcludes   []string    `json:"json_excludes,omitempty" yaml:"json_excludes,omitempty"`
+	JSONRegexps    []string    `json:"json_regexps,omitempty" yaml:"json_regexps,omitempty"`
 }
 
 // Executor struct. Json and yaml descriptor are used for json output


### PR DESCRIPTION
Added assertions with regular expressions:

## For body

With `bodyRegexp` assertion:

```yaml
response:
  bodyRegexp: "foo.*bar"
```

## For Headers

With `headersRegexps` clause to indicate that given header assertion is a regexp:

```yaml
response:
  headers:
    Set-Cookie: "foo=bar; Path=/; Expires=.*?; HttpOnly; SameSite=None"
  headersRegexps:
  - "Set-Cookie"
```

## For JSON

With `jsonRegexps` clause to indicate that given JSON field assertion is a regexp:

```yaml
response:
  json:
    foo: "e.*s"
  jsonRegexps:
  - "foo"
```
